### PR TITLE
Fix for the text selection in Eclipse Mars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.jar
 *.war
 *.ear
+/bin/

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,11 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DashLookup
 Bundle-SymbolicName: com.jkb.dashlookup;singleton:=true
-Bundle-Version: 1.0.5
+Bundle-Version: 1.0.6
 Bundle-Activator: dashlookup.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Import-Package: org.eclipse.jface.text
+Import-Package: org.eclipse.jface.text,
+ org.eclipse.ui.texteditor
 Bundle-Vendor: Quaerendo Games

--- a/src/dashlookup/handlers/DashLookupHandler.java
+++ b/src/dashlookup/handlers/DashLookupHandler.java
@@ -3,12 +3,14 @@ package dashlookup.handlers;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.swt.program.Program;
-import org.eclipse.ui.ISelectionService;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.swt.program.Program;
+import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 /**
  * Our sample handler extends AbstractHandler, an IHandler base class.
@@ -29,16 +31,38 @@ public class DashLookupHandler extends AbstractHandler {
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
-		ISelectionService service = window.getSelectionService();
 
-		if (service != null) {
-			ISelection selection = service.getSelection();
-			if (selection instanceof ITextSelection) {
-				String selectedText = ((ITextSelection) selection).getText();
-				if (!selectedText.isEmpty())
-					Program.launch("dash://" + selectedText);
-			}
+		String selectedText = getSelectedText(window);
+		
+		if (selectedText.isEmpty() && window.getActivePage() != null) {
+			selectedText = getTextFromSelection(window.getActivePage().getSelection());
 		}
+		
+		if (!selectedText.isEmpty()) {
+			Program.launch("dash://" + selectedText);
+		}
+		
 		return null;
 	}
+	
+	private String getTextFromSelection(ISelection selection) {
+		String selectedText = "";
+		if (selection instanceof ITextSelection) {
+			selectedText = ((ITextSelection) selection).getText();
+		}
+		
+		return selectedText;
+	}
+
+	private String getSelectedText(IWorkbenchWindow window) {
+		String selectedText = "";
+		final ISelectionService service = window.getSelectionService();
+
+		if (service != null) {
+			selectedText = getTextFromSelection(service.getSelection());
+		}
+		
+		return selectedText;
+	}
+
 }

--- a/src/dashlookup/handlers/DashLookupHandler.java
+++ b/src/dashlookup/handlers/DashLookupHandler.java
@@ -7,10 +7,8 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.program.Program;
 import org.eclipse.ui.ISelectionService;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.eclipse.ui.texteditor.ITextEditor;
 
 /**
  * Our sample handler extends AbstractHandler, an IHandler base class.


### PR DESCRIPTION
The selected text in text editor is not correctly looked up in Eclipse Mars (OS X 10.10).
Add alternative lookup from the active page if original lookup does not find the selected text. See also 
http://wiki.eclipse.org/FAQ_How_do_I_find_out_what_object_is_selected%3F.
